### PR TITLE
A space is expected after the package line

### DIFF
--- a/plugin/grailsImport.vim
+++ b/plugin/grailsImport.vim
@@ -104,6 +104,7 @@ function! CreateImports(pathList)
         endif
         if (g:grails_import_auto_organize)
             :call OrganizeImports()
+            :call SpaceAfterPackage()
         endif
         if len(a:pathList) > 1
             echom "Warning: Multiple imports created!"
@@ -190,6 +191,29 @@ endfunction
 
 command! InsertImport :call InsertImport()
 map <D-i> :InsertImport <CR>
+
+function! SpaceAfterPackage()
+    :let pos = getpos('.')
+
+    :execute "normal gg"
+    :let packageStart = search("^package")
+    if packageStart == 0
+        return
+    endif
+
+    :let importStart = search("^import")
+    if importStart == 0
+        return
+    endif
+
+    :let expectedImportStart = (packageStart + 2)
+    if importStart != expectedImportStart
+        :execute "normal O"
+    endif
+
+    call setpos('.', pos)
+endfunction
+command! SpaceAfterPackage :call SpaceAfterPackage()
 
 function! OrganizeImports()
     :let pos = getpos('.')


### PR DESCRIPTION
OrganizeImports was removing the space between `package` and the first `import` line.
Example:

```
package org.zirbes.bobbyconf
import org.zirbes.bobbyconf.js.node.Nan
import org.zirbes.bobbyconf.js.angular.DirectThis
import org.zirbes.bobbyconf.js.react.PutTheHtmlWhere
```

This ensures there is always a space between the two
